### PR TITLE
Fix image grid layout after Gatsby v5 upgrade

### DIFF
--- a/src/components/BackgroundImage.js
+++ b/src/components/BackgroundImage.js
@@ -1,19 +1,38 @@
-import { GatsbyImage } from 'gatsby-plugin-image'
+import React from 'react'
+import { GatsbyImage, getImage } from 'gatsby-plugin-image'
 import styled from 'styled-components'
 
-const BackgroundImage = styled(GatsbyImage)`
-  position: absolute;
-  top: 0;
-  left: 0;
+const Frame = styled.div`
+  position: relative;
   width: 100%;
-  z-index: -1;
-  height: 100%;
+  ${({ $aspectRatio }) =>
+    $aspectRatio ? `aspect-ratio: ${$aspectRatio};` : `height: 100%;`}
 
-  // Adjust image positioning (if image covers area with defined height)
-  & > img {
+  .gatsby-image-wrapper {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+  }
+
+  img {
     object-fit: cover !important;
     object-position: 0% 0% !important;
   }
 `
+
+const BackgroundImage = ({ sizes, image, alt = '', className }) => {
+  const source = image || sizes
+  if (!source) return null
+
+  const img = getImage(source)
+  if (!img) return null
+
+  return (
+    <Frame $aspectRatio={source.aspectRatio} className={className}>
+      <GatsbyImage image={img} alt={alt} />
+    </Frame>
+  )
+}
 
 export default BackgroundImage

--- a/src/components/Gallery.js
+++ b/src/components/Gallery.js
@@ -62,44 +62,22 @@ class Gallery extends React.Component {
           {photos.map((image, idx) => {
             const src = getSrc(image.node)
             const basename = getBasename(src)
+            const isVideo = Boolean(this.props.videos[basename])
             return (
               <Frame key={idx}>
-                {this.props.videos[basename] ? (
-                  <a
-                    href={src}
-                    onClick={e => this.showVideo(this.props.videos[basename], e)}
-                  >
-                    <div
-                      style={{
-                        position: 'relative',
-                      }}
-                    >
-                      <GatsbyImage
-                        image={getImage(image.node)}
-                        alt=""
-                      />
-                      <img
-                        src={play}
-                        style={{
-                          position: 'absolute',
-                          maxWidth: '100%',
-                          top: '40%',
-                        }}
-                        alt="Play"
-                      />
-                    </div>
-                  </a>
-                ) : (
-                  <a
-                    href={src}
-                    onClick={e => this.openLightbox(idx, e)}
-                  >
-                    <GatsbyImage
-                      image={getImage(image.node)}
-                      alt=""
-                    />
-                  </a>
-                )}
+                <a
+                  href={src}
+                  onClick={e =>
+                    isVideo
+                      ? this.showVideo(this.props.videos[basename], e)
+                      : this.openLightbox(idx, e)
+                  }
+                >
+                  <Thumb>
+                    <GatsbyImage image={getImage(image.node)} alt="" />
+                    {isVideo && <PlayIcon src={play} alt="Play" />}
+                  </Thumb>
+                </a>
               </Frame>
             )
           })}
@@ -155,6 +133,34 @@ const Frame = styled.div`
     flex: 1 0 50%;
     max-width: 50%;
   `};
+`
+
+const Thumb = styled.div`
+  position: relative;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  overflow: hidden;
+
+  .gatsby-image-wrapper {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+  }
+
+  img {
+    object-fit: cover !important;
+    object-position: center !important;
+  }
+`
+
+const PlayIcon = styled.img`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  max-width: 40%;
+  pointer-events: none;
 `
 
 export default Gallery


### PR DESCRIPTION
BackgroundImage and Gallery were not migrated to the gatsby-plugin-image API — they passed raw data via a sizes prop that GatsbyImage ignores, causing empty containers and collapsed/overlapping headings.

Rewrite BackgroundImage as a functional wrapper that resolves the image with getImage() and renders GatsbyImage with the correct image prop. Honor an explicit aspectRatio override via CSS aspect-ratio, otherwise fill the flex parent via height: 100% so Quarter cells stretch to the row height set by sibling Half cells.

Force all Gallery thumbnails to a uniform 4:3 aspect ratio with object-fit: cover, mirroring the pre-upgrade behavior.